### PR TITLE
build(deps): bump golang.org/x/net from 0.23.0 to 0.55.0 in /ms-paymentagr

### DIFF
--- a/ms-paymentagr/go.mod
+++ b/ms-paymentagr/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect


### PR DESCRIPTION
Fixes Dependabot security alerts for golang.org/x/net (CVE-2025-22872, CVE-2025-22870, CVE-2025-47914-class net issues). Patched in v0.55.0.

Note: go.sum should be refreshed (go mod tidy) when merging; this bumps the indirect requirement in go.mod.