### PR TITLE
build(deps): bump org.apache.kafka:kafka-clients from 3.4.0 to 3.9.2 in /ms-order

### DIFF
--- a/ms-order/pom.xml
+++ b/ms-order/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.4.0</version>
+			<version>3.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Fixes Dependabot security alerts for kafka-clients (CVE-2026-35554, CVE-2026-33558, CVE-2025-27817). Patched in 3.9.2.