### PR TITLE
ci: fix broken Docker build by replacing removed openjdk:17-jdk-slim image

### DIFF
--- a/ms-invoice/ms-invoice.dockerfile
+++ b/ms-invoice/ms-invoice.dockerfile
@@ -12,7 +12,7 @@ COPY src /app/src
 RUN mvn clean install
 
 # Start with a clean base image for the runtime
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 # Install necessary libraries
 RUN apt-get update && \

--- a/ms-logger/ms-logger.dockerfile
+++ b/ms-logger/ms-logger.dockerfile
@@ -11,7 +11,7 @@ COPY src /app/src
 # Run the Maven build (clean install)
 RUN mvn clean install
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 

--- a/ms-order/ms-order.dockerfile
+++ b/ms-order/ms-order.dockerfile
@@ -11,7 +11,7 @@ COPY src /app/src
 # Run the Maven build (clean install)
 RUN mvn clean install
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 

--- a/ms-payment/ms-payment.dockerfile
+++ b/ms-payment/ms-payment.dockerfile
@@ -11,7 +11,7 @@ COPY src /app/src
 # Run the Maven build (clean install)
 RUN mvn clean install
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 


### PR DESCRIPTION
## Fix CI: replace removed `openjdk:17-jdk-slim` base image

The `CI/CD Pipeline` (Build and run services with Docker Compose) was failing on **all** PRs at the very first image resolution:

```
#10 [ms-invoice internal] load metadata for docker.io/library/openjdk:17-jdk-slim
#10 ERROR: docker.io/library/openjdk:17-jdk-slim: not found
failed to solve: openjdk:17-jdk-slim: ... not found
```

The `library/openjdk` images were deprecated and **removed from Docker Hub in 2024**, so the tag no longer exists (verified HTTP 404). This broke the pipeline before it ever compiled any code, so it was unrelated to the dependency security bumps.

### Change
Replaced `FROM openjdk:17-jdk-slim` with `FROM eclipse-temurin:17-jdk` (the official, maintained OpenJDK 17 distribution; HTTP 200, Debian-based, supports `apt-get`/`libfreetype6`) in all four Java service Dockerfiles:
- ms-invoice
- ms-order
- ms-logger
- ms-payment

The build stage `maven:3.8.5-openjdk-17` and the Go/`mongo` images were already valid and are unchanged.

After this, the security-bump PRs (#11–#14) should be buildable and their CI can be validated.